### PR TITLE
Add pr/postcommit jobs for kraken-services

### DIFF
--- a/job-list.yaml.inc
+++ b/job-list.yaml.inc
@@ -2,6 +2,8 @@
 - '{name}-postcommit'
 - '{name}-ci-jobs-pr'
 - '{name}-ci-jobs-postcommit'
+- '{name}-services-pr'
+- '{name}-services-postcommit'
 - '{name}-build-cluster'
 - '{name}-build-kubernetes'
 - '{name}-clean-kubernetes'

--- a/kraken-services-postcommit/kraken-services-postcommit.yaml
+++ b/kraken-services-postcommit/kraken-services-postcommit.yaml
@@ -1,0 +1,33 @@
+---
+- job-template:
+    name: '{name}-services-postcommit'
+    description: 'Do not edit this job through the web! Runs on post-commit to kraken, kicks off conformance tests'
+    concurrent: false
+    project-type: freestyle
+    logrotate:
+      numToKeep: 100
+    properties:
+      - github:
+          url: https://github.com/samsung-cnct/kraken-services/
+    scm:
+      - git:
+          url: https://github.com/samsung-cnct/kraken-services.git
+          credentials-id: jenkins-ssh
+          branches:
+            - master
+          browser: auto
+          wipe-workspace: false
+          skip-tag: true
+    triggers:
+      - github
+    wrappers:
+      - workspace-cleanup
+    builders:
+      - shell: ./build.sh --repo quay.io/samsung_cnct --tag latest --push .
+    publishers:
+      - slack-publisher:
+          slack_domain: '{slack_domain}'
+          slack_api_token: '{slack_api_token}'
+          ci_hostname: '{ci_hostname}'
+          slack_room: '{slack_room}'
+

--- a/kraken-services-pr/kraken-services-pr.yaml
+++ b/kraken-services-pr/kraken-services-pr.yaml
@@ -1,0 +1,35 @@
+---
+- job-template:
+    name: '{name}-services-pr'
+    description: 'Do not edit this job through the web! Runs against pull requests made against kraken-services'
+    project-type: freestyle
+    logrotate:
+      numToKeep: 100
+    properties:
+      - github:
+          url: https://github.com/samsung-cnct/kraken-services/
+    scm:
+      - git:
+          url: git@github.com:samsung-cnct/kraken-services.git
+          credentials-id: jenkins-ssh
+          refspec: "+refs/pull/*:refs/remotes/origin/pr/*"
+          branches:
+            - ${{ghprbActualCommit}}
+          browser: auto
+          wipe-workspace: false
+          skip-tag: true
+    wrappers:
+      - workspace-cleanup
+      - mask-passwords
+    triggers:
+      - github-pull-request:
+          admin-list: '{obj:ci_admin_list}'
+          github-hooks: true
+    builders:
+      - shell: ./build.sh --repo quay.io/samsung_cnct --tag ${{ghprbActualCommit}} .
+    publishers:
+      - slack-publisher:
+          slack_domain: '{slack_domain}'
+          slack_api_token: '{slack_api_token}'
+          ci_hostname: '{ci_hostname}'
+          slack_room: '{slack_room}'


### PR DESCRIPTION
The PR job will build, with a tag of the current commit

The postcommit job will build and push, with a tag of latest

Open to adding the option to use other tags as well as latest if we
feel there's value (eg: build number, git commit)