### PR TITLE
Revert "Update Jenkins to push all collected logs to S3. This change is"

### DIFF
--- a/kraken-run-k8s-conformance-tests/include-raw001-kraken-run-k8s-conformance-tests.sh
+++ b/kraken-run-k8s-conformance-tests/include-raw001-kraken-run-k8s-conformance-tests.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-KRAKEN_ROOT=${KRAKEN_ROOT:-${WORKSPACE}}
-
 ${WORKSPACE}/bin/kraken-connect.sh \
   --clustername "${KRAKEN_CLUSTER_NAME}" \
   --clustertype aws \
@@ -15,14 +12,8 @@ export KUBE_CONFORMANCE_OUTPUT_DIR=${WORKSPACE}/output/conformance
 export KUBE_SSH_USER="core"
 export KUBE_SSH_KEY="${KRAKEN_CLUSTER_DIR}/id_rsa"
 
-# setup logging
-KUBE_CONFORMANCE_LOG_DIR=${KRAKEN_ROOT}/kraken_${GIT_COMMIT}/
-KUBE_CONFORMANCE_LOG=${KUBE_CONFORMANCE_LOG_DIR}/build-log.txt
-
+KUBE_CONFORMANCE_LOG=${WORKSPACE}/kraken_${GIT_COMMIT}.log
 # TODO: unclear what part of k8s scripts require USER to be set
 USER=jenkins ./hack/conformance.sh ${KUBE_TESTS_BRANCH} | tee ${KUBE_CONFORMANCE_LOG}
 # tee isn't exiting >0 as expected, so use the exit status of the script directly
 exit ${PIPESTATUS[0]}
-
-# save logs
-${KRAKEN_ROOT}/hack/log-dump.sh --clustername ${KRAKEN_CLUSTER_NAME} --log-directory ${KUBE_CONFORMANCE_LOG_DIR}/artifacts

--- a/kraken-run-k8s-conformance-tests/run-k8s-conformance-tests.yaml
+++ b/kraken-run-k8s-conformance-tests/run-k8s-conformance-tests.yaml
@@ -32,7 +32,7 @@
           !include-raw-escape: include-raw001-kraken-run-k8s-conformance-tests.sh
     publishers:
       - archive:
-          artifacts: kraken_${{GIT_COMMIT}}
+          artifacts: kraken_${{GIT_COMMIT}}.log
       - trigger-parameterized-builds:
         - project: '{name}-upload-to-s3-kraken-e2e-logs'
           current-parameters: true
@@ -40,7 +40,7 @@
             TEST_KIND=conformance
             PROJECT_NAME=${{JOB_NAME}}
             PROJECT_BUILD=${{BUILD_NUMBER}}
-            PROJECT_ARTIFACT=kraken_${{GIT_COMMIT}}
+            PROJECT_ARTIFACT=kraken_${{GIT_COMMIT}}.log
           condition: ALWAYS
       - junit:
           results: output/**/junit*.xml

--- a/kraken-run-k8s-density-tests/include-raw001-kraken-run-k8s-density-tests.sh
+++ b/kraken-run-k8s-density-tests/include-raw001-kraken-run-k8s-density-tests.sh
@@ -28,12 +28,9 @@ KUBECONFIG=${KUBECONFIG} ${KRAKEN_ROOT}/hack/terminate-namespace.sh density
 
 ## run
 
-# setup logging
-KUBE_DENSITY_LOG_DIR=${KRAKEN_ROOT}/${BUILD_TAG}-${DENSITY}/
-KUBE_DENSITY_LOG=${KUBE_DENSITY_LOG_DIR}/build-log.txt
-
 # TODO: unclear what part of k8s scripts require USER to be set
 # TODO: should we just drop test build functionality
+KUBE_DENSITY_LOG=${KRAKEN_ROOT}/${BUILD_TAG}-${DENSITY}.log
 export KUBE_ROOT=${KUBE_ROOT:-"/var/lib/docker/gobuild/${KUBE_TESTS_DIR}"}
 export KUBE_DENSITY_KUBECONFIG=${KUBECONFIG}
 export KUBE_DENSITY_NUM_NODES=${NUMBER_OF_NODES}
@@ -43,9 +40,6 @@ export KUBE_SSH_KEY="${KRAKEN_CLUSTER_DIR}/id_rsa"
 REBUILD_TESTS=false USER=jenkins ${KRAKEN_ROOT}/hack/density.sh ${KUBE_TESTS_BRANCH} ${DENSITY} | tee ${KUBE_DENSITY_LOG}
 # tee isn't exiting >0 as expected, so use the exit status of the script directly
 density_result=${PIPESTATUS[0]}
-
-# save logs
-${KRAKEN_ROOT}/hack/log-dump.sh --clustername ${KRAKEN_CLUSTER_NAME} --log-directory ${KRAKEN_ROOT}/${BUILD_TAG}-${DENSITY}/artifacts
 
 ## teardown
 

--- a/kraken-run-k8s-density-tests/kraken-run-k8s-density-tests.yaml
+++ b/kraken-run-k8s-density-tests/kraken-run-k8s-density-tests.yaml
@@ -43,7 +43,7 @@
             TEST_KIND=density
             PROJECT_NAME=${{JOB_NAME}}
             PROJECT_BUILD=${{BUILD_NUMBER}}
-            PROJECT_ARTIFACT=${{BUILD_TAG}}-${{DENSITY}}
+            PROJECT_ARTIFACT=${{BUILD_TAG}}-${{DENSITY}}.log
           condition: ALWAYS
         - project: '{name}-update-github-pages'
           current-parameters: true
@@ -51,7 +51,7 @@
             KRAKEN_COMMIT=${{BUILD_TAG}}-${{DENSITY}}
             TEST_RESULT=Success!
             TEST_KIND=density
-            LOG_LINK=http://s3-us-west-2.amazonaws.com/{test_bucket}/density/${{BUILD_TAG}}-${{DENSITY}}/build-log.txt
+            LOG_LINK=http://s3-us-west-2.amazonaws.com/{test_bucket}/density/${{BUILD_TAG}}-${{DENSITY}}.log
           condition: SUCCESS
         - project: '{name}-update-github-pages'
           current-parameters: true
@@ -59,7 +59,7 @@
             KRAKEN_COMMIT=${{BUILD_TAG}}-${{DENSITY}}
             TEST_RESULT=Failure!
             TEST_KIND=density
-            LOG_LINK=http://s3-us-west-2.amazonaws.com/{test_bucket}/density/${{BUILD_TAG}}-${{DENSITY}}/build-log.txt
+            LOG_LINK=http://s3-us-west-2.amazonaws.com/{test_bucket}/density/${{BUILD_TAG}}-${{DENSITY}}.log
           condition: UNSTABLE_OR_WORSE
       - junit:
           results: output/**/junit*.xml

--- a/kraken-upload-to-s3-kraken-e2e-logs/include-raw001-kraken-upload-to-s3-kraken-e2e-logs.sh
+++ b/kraken-upload-to-s3-kraken-e2e-logs/include-raw001-kraken-upload-to-s3-kraken-e2e-logs.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-aws s3 cp --recursive --acl public-read --content-type text/plain --metadata-directive REPLACE ${PROJECT_ARTIFACT} s3://kraken-e2e-logs/${TEST_KIND}/
+aws s3 cp --acl public-read --content-type text/plain --metadata-directive REPLACE ${PROJECT_ARTIFACT} s3://kraken-e2e-logs/${TEST_KIND}/


### PR DESCRIPTION
Reverts samsung-cnct/kraken-ci-jobs#56 because the current JJB changes are incorrect and now we are not collecting any logs for density or conformance tests.