### PR TITLE
Fix typo

### DIFF
--- a/kraken-ci-jobs-postcommit/include-raw001-kraken-ci-jobs-postcommit.sh
+++ b/kraken-ci-jobs-postcommit/include-raw001-kraken-ci-jobs-postcommit.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cp /etc/jenkins_jobs/jenkins_jobs.ini .
 cp /etc/jenkins_jobs/slack-publisher.yaml .
-jenkins-jobs update --delete-old --recursive --exclude jobs/excluded-on-jenkins .
+jenkins-jobs update --delete-old --recursive --exclude excluded-on-jenkins .


### PR DESCRIPTION
We now load in jobs directly from the cwd instead of going to a
known hardcoded git repo maintained by kraken-ci