### PR TITLE
use output/ dir for all artifacts

### DIFF
--- a/kraken-run-k8s-conformance-tests/include-raw001-kraken-run-k8s-conformance-tests.sh
+++ b/kraken-run-k8s-conformance-tests/include-raw001-kraken-run-k8s-conformance-tests.sh
@@ -5,7 +5,7 @@ KRAKEN_ROOT=${KRAKEN_ROOT:-${WORKSPACE}}
 ## setup
 
 # setup output dir
-OUTPUT_DIR="${KRAKEN_ROOT}/kraken_${GIT_COMMIT}"
+OUTPUT_DIR="${KRAKEN_ROOT}/output"
 mkdir -p "${OUTPUT_DIR}/artifacts"
 
 # ensure we have access to a kraken cluster

--- a/kraken-run-k8s-conformance-tests/kraken-run-k8s-conformance-tests.yaml
+++ b/kraken-run-k8s-conformance-tests/kraken-run-k8s-conformance-tests.yaml
@@ -28,9 +28,9 @@
           !include-raw-escape: include-raw001-kraken-run-k8s-conformance-tests.sh
     publishers:
       - archive:
-          artifacts: kraken_${{GIT_COMMIT}}/build-log.txt, kraken_${{GIT_COMMIT}}/artifacts/**/*
+          artifacts: output/build-log.txt, output/artifacts/**/*
       - upload-to-s3-publisher:
-          source: kraken_${{GIT_COMMIT}}
+          source: output
           destination: s3://kraken-e2e-logs/conformance/kraken_${{GIT_COMMIT}}
       - trigger-parameterized-builds:
         - project: '{name}-update-github-pages'

--- a/kraken-run-k8s-density-tests/include-raw001-kraken-run-k8s-density-tests.sh
+++ b/kraken-run-k8s-density-tests/include-raw001-kraken-run-k8s-density-tests.sh
@@ -5,7 +5,7 @@ KRAKEN_ROOT=${KRAKEN_ROOT:-${WORKSPACE}}
 ## setup
 
 # setup output dir
-OUTPUT_DIR="${KRAKEN_ROOT}/${BUILD_TAG}-${DENSITY}"
+OUTPUT_DIR="${KRAKEN_ROOT}/output"
 mkdir -p "${OUTPUT_DIR}/artifacts"
 
 # ensure we have access to a kraken cluster

--- a/kraken-run-k8s-density-tests/kraken-run-k8s-density-tests.yaml
+++ b/kraken-run-k8s-density-tests/kraken-run-k8s-density-tests.yaml
@@ -31,9 +31,9 @@
           !include-raw-escape: include-raw001-kraken-run-k8s-density-tests.sh
     publishers:
       - archive:
-          artifacts: ${{BUILD_TAG}}-${{DENSITY}}/build-log.txt, ${{BUILD_TAG}}-${{DENSITY}}/artifacts/**/*
+          artifacts: output/build-log.txt, output/artifacts/**/*
       - upload-to-s3-publisher:
-          source: ${{BUILD_TAG}}-${{DENSITY}}
+          source: output
           destination: s3://kraken-e2e-logs/density/${{BUILD_TAG}}-${{DENSITY}}
       - trigger-parameterized-builds:
         - project: '{name}-update-github-pages'


### PR DESCRIPTION
discovered the junit publisher was pointed at output, but my last change
had the junit results landing in job-specific-dir/artifacts/

change both jobs to dump to output, but they'll still upload to s3 using
job-specific-dir as the destination