### PR TITLE
fix kraken-pr job

### DIFF
--- a/scripts/include-raw001-kraken-pr.sh
+++ b/scripts/include-raw001-kraken-pr.sh
@@ -6,13 +6,9 @@ cat > terraform/aws/${KRAKEN_CLUSTER_NAME}/terraform.tfvars << EOF
 aws_user_prefix = "${KRAKEN_USER_PREFIX}"
 aws_access_key = "${AWS_ACCESS_KEY_ID}"
 aws_secret_key = "${AWS_SECRET_ACCESS_KEY}"
-kubernetes_binaries_uri = "${KUBE_BINARIES_URI}"
 asg_wait_single = 60
 asg_wait_total = 10
 kraken_repo.commit_sha = "${ghprbActualCommit}"
-kraken_services_repo = "${KRAKEN_SERVICES_REPO}"
-kraken_services_branch = "${KRAKEN_SERVICES_BRANCH}"
-kraken_services_dirs = "${KRAKEN_SERVICES_DIRS}"
 EOF
 
 # start kraken-up


### PR DESCRIPTION
the removal of params meant some required variables were getting
rendered with empty values, which was preventing clusters from
coming up

instead, use the defaults specified in terraform/aws/variables.tf,
that way PR's that change the defaults will actually have the new
defaults exercised