### PR TITLE
Adding updated fabric - GKE seems to lack fabric anyway?

### DIFF
--- a/k2-configs/default-e2e.yaml
+++ b/k2-configs/default-e2e.yaml
@@ -29,12 +29,29 @@ deployment:
   fabric:
     provider: flannel
     options:
-      Network: 10.128.0.0/10
-      SubnetLen: 22
-      SubnetMin: 10.128.0.0
-      SubnetMax: 10.191.255.255
-      Backend:
-        Type: vxlan
+      containers:
+        kubePolicyController:
+          version: v0.5.1
+          location: calico/kube-policy-controller
+        etcd:
+          version: v3.0.9
+          location: quay.io/coreos/etcd
+        calicoCni:
+          version: v1.4.2
+          location: calico/cni
+        calicoNode:
+          version: v1.0.0-rc1
+          location: quay.io/calico/node
+        flannel:
+          version: v0.6.1
+          location: quay.io/coreos/flannel
+      network:
+        network: 10.128.0.0/10
+        subnetLen: 22
+        subnetMin: 10.128.0.0
+        subnetMax: 10.191.255.255
+        backend:
+          type: vxlan
   provider: aws
   providerConfig:
     resourcePrefix:

--- a/k2-configs/default-pr-aws.yaml
+++ b/k2-configs/default-pr-aws.yaml
@@ -29,12 +29,29 @@ deployment:
   fabric:
     provider: flannel
     options:
-      Network: 10.128.0.0/10
-      SubnetLen: 22
-      SubnetMin: 10.128.0.0
-      SubnetMax: 10.191.255.255
-      Backend:
-        Type: vxlan
+      containers:
+        kubePolicyController:
+          version: v0.5.1
+          location: calico/kube-policy-controller
+        etcd:
+          version: v3.0.9
+          location: quay.io/coreos/etcd
+        calicoCni:
+          version: v1.4.2
+          location: calico/cni
+        calicoNode:
+          version: v1.0.0-rc1
+          location: quay.io/calico/node
+        flannel:
+          version: v0.6.1
+          location: quay.io/coreos/flannel
+      network:
+        network: 10.128.0.0/10
+        subnetLen: 22
+        subnetMin: 10.128.0.0
+        subnetMax: 10.191.255.255
+        backend:
+          type: vxlan
   provider: aws
   providerConfig:
     resourcePrefix:

--- a/k2-configs/default-pr-gke.yaml
+++ b/k2-configs/default-pr-gke.yaml
@@ -18,6 +18,32 @@ deployment:
       additionalZones: 
         - us-central1-b
         - us-central1-c
+  fabric:
+    provider: flannel
+    options:
+      containers:
+        kubePolicyController:
+          version: v0.5.1
+          location: calico/kube-policy-controller
+        etcd:
+          version: v3.0.9
+          location: quay.io/coreos/etcd
+        calicoCni:
+          version: v1.4.2
+          location: calico/cni
+        calicoNode:
+          version: v1.0.0-rc1
+          location: quay.io/calico/node
+        flannel:
+          version: v0.6.1
+          location: quay.io/coreos/flannel
+      network:
+        network: 10.128.0.0/10
+        subnetLen: 22
+        subnetMin: 10.128.0.0
+        subnetMax: 10.191.255.255
+        backend:
+          type: vxlan
   nodepool:
     -
       name: default


### PR DESCRIPTION
I added the fabric node for GKE configuration - unsure why it was lacking to begin with.  This should cause the tests to pass now