### PR TITLE
increase resource limits to make conformance not-resource constrained

### DIFF
--- a/k2-configs/default-e2e.yaml
+++ b/k2-configs/default-e2e.yaml
@@ -219,7 +219,7 @@ deployment:
       coreos: allNodes
     -
       name: clusterNodes
-      count: 3
+      count: 5
       keypair: krakenKey
       mounts:
         -
@@ -227,7 +227,7 @@ deployment:
           path: /var/lib/docker
           forceFormat: true
       providerConfig:
-        type: c4.large
+        type: c4.xlarge
         subnet: ["uwswest2a", "uwswest2b", "uwswest2c"]
         tags:
           -

--- a/k2-configs/default-pr-aws.yaml
+++ b/k2-configs/default-pr-aws.yaml
@@ -219,7 +219,7 @@ deployment:
       coreos: allNodes
     -
       name: clusterNodes
-      count: 3
+      count: 5
       keypair: krakenKey
       mounts:
         -
@@ -227,7 +227,7 @@ deployment:
           path: /var/lib/docker
           forceFormat: true
       providerConfig:
-        type: c4.large
+        type: c4.xlarge
         subnet: ["uwswest2a", "uwswest2b", "uwswest2c"]
         tags:
           -


### PR DESCRIPTION
with the move from host level flannel networking to k8s hosted canal
networking we need to account for networking components as part of
k8s resources instead of ignoring them as part of the host system.
this resource bump gives us plenty of headroom for running conformance