### PR TITLE
set an explicit GOPATH for jobs that run e2e tests

### DIFF
--- a/scripts/include-raw001-k2-run-k8s-conformance-tests.sh
+++ b/scripts/include-raw001-k2-run-k8s-conformance-tests.sh
@@ -8,6 +8,10 @@ K2_ROOT=${K2_ROOT:-${WORKSPACE}}
 OUTPUT_DIR="${K2_ROOT}/output"
 mkdir -p "${OUTPUT_DIR}/artifacts"
 
+# setup gopath
+export GOPATH="${WORKSPACE}/go"
+mkdir -p "${GOPATH}"
+
 ## run
 export KUBE_ROOT=/var/lib/docker/gobuild/${KUBE_TESTS_DIR}
 export KUBE_CONFORMANCE_KUBECONFIG=${WORKSPACE}/${K2_CLUSTER_NAME}/${K2_CLUSTER_NAME}/admin.kubeconfig

--- a/scripts/include-raw001-kraken-run-k8s-conformance-tests.sh
+++ b/scripts/include-raw001-kraken-run-k8s-conformance-tests.sh
@@ -8,6 +8,10 @@ KRAKEN_ROOT=${KRAKEN_ROOT:-${WORKSPACE}}
 OUTPUT_DIR="${KRAKEN_ROOT}/output"
 mkdir -p "${OUTPUT_DIR}/artifacts"
 
+# setup gopath
+export GOPATH="${WORKSPACE}/go"
+mkdir -p "${GOPATH}"
+
 # ensure we have access to a kraken cluster
 ${WORKSPACE}/bin/kraken-connect.sh \
   --clustername "${KRAKEN_CLUSTER_NAME}" \

--- a/scripts/include-raw001-kraken-run-k8s-density-tests.sh
+++ b/scripts/include-raw001-kraken-run-k8s-density-tests.sh
@@ -8,6 +8,10 @@ KRAKEN_ROOT=${KRAKEN_ROOT:-${WORKSPACE}}
 OUTPUT_DIR="${KRAKEN_ROOT}/output"
 mkdir -p "${OUTPUT_DIR}/artifacts"
 
+# setup gopath
+export GOPATH="${WORKSPACE}/go"
+mkdir -p "${GOPATH}"
+
 # ensure we have access to a kraken cluster
 ${KRAKEN_ROOT}/bin/kraken-connect.sh \
   --clustername "${KRAKEN_CLUSTER_NAME}" \


### PR DESCRIPTION
as of kubernetes 1.6.x, `kubernetes/hack/e2e.go` is a wrapper that
ends up `go get`'ing another tool `kubetest`... it needs a GOPATH
to install to

use a GOPATH local to each job invocation rather than sharing

ref #162