### PR TITLE
k2-283 changes in default config and DNS not in helm anymore

### DIFF
--- a/k2-configs/default-e2e.yaml
+++ b/k2-configs/default-e2e.yaml
@@ -314,16 +314,12 @@ deployment:
       -
         name: atlas
         url: http://atlas.cnct.io
-    services:
-      -
+    kubedns:
         name: kubedns
-        repo: atlas
-        chart: kubedns
-        version: 0.1.0
         namespace: kube-system
-        values:
-          cluster_ip: 10.32.0.2
-          dns_domain: cluster.local
+        cluster_ip: 10.32.0.2
+        dns_domain: cluster.local
+    services:
       -
         name: heapster
         repo: atlas

--- a/k2-configs/default-pr-aws.yaml
+++ b/k2-configs/default-pr-aws.yaml
@@ -314,16 +314,12 @@ deployment:
       -
         name: atlas
         url: http://atlas.cnct.io
-    services:
-      -
+    kubedns:
         name: kubedns
-        repo: atlas
-        chart: kubedns
-        version: 0.1.0
         namespace: kube-system
-        values:
-          cluster_ip: 10.32.0.2
-          dns_domain: cluster.local
+        cluster_ip: 10.32.0.2
+        dns_domain: cluster.local
+    services:
       -
         name: heapster
         repo: atlas

--- a/scripts/include-raw001-k2-pr-aws.sh
+++ b/scripts/include-raw001-k2-pr-aws.sh
@@ -2,13 +2,6 @@
 NODECOUNT=7
 
 # make sure everything deployed ok
-docker run \
-  -e "KUBECONFIG=${WORKSPACE}/${K2_CLUSTER_NAME}/ci-pr-${ghprbPullId}-aws/admin.kubeconfig" \
-  -e "HELM_HOME=${WORKSPACE}/${K2_CLUSTER_NAME}/ci-pr-${ghprbPullId}-aws/.helm" \
-  --volumes-from=jenkins \
-  ${K2_CONTAINER_IMAGE} \
-  helm status kubedns | grep "STATUS\: DEPLOYED" || { echo 'kubedns release did not deploy'; exit 1; }
-
 node_count=$(docker run \
   -e "KUBECONFIG=${WORKSPACE}/${K2_CLUSTER_NAME}/ci-pr-${ghprbPullId}-aws/admin.kubeconfig" \
   --volumes-from=jenkins \


### PR DESCRIPTION
change to new kubedns config stanza.
remove helm check for kubedns...it is not deployed that way anymore.
leave in the kubectl check for kubedns...this is still correct.